### PR TITLE
Remove path accumulation on forward pass

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,7 +150,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "dendritic"
-version = "2.0.3"
+version = "2.0.4"
 dependencies = [
  "chrono",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dendritic"
-version = "2.0.4"
+version = "2.1.0"
 edition = "2021"
 description = "Iterative Optimization Library"
 publish = true


### PR DESCRIPTION
The forward pass was accumulating the path on every iteration which was leading to large paths being serialized. Added a `fill_path` boolean to only fill the path on first initialization. 